### PR TITLE
rev 4.0 has longer content hashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function plugin(keepQuantity) {
     var lists = {};
 
     return through.obj(function (file, enc, cb) {
-        var regex = new RegExp('^(.*)-[0-9a-f]{8}(?:\\.min)?\\' + path.extname(file.path) + '$');
+        var regex = new RegExp('^(.*)-[0-9a-f]{8,10}(?:\\.min)?\\' + path.extname(file.path) + '$');
         if (regex.test(file.path)) {
             var identifier = regex.exec(file.path)[1] + path.extname(file.path);
             if (lists[identifier] === undefined) {


### PR DESCRIPTION
Just noticed that gulp-rev 4.0 now has 10-character content hashes instead 8. This small change to the regex catches those newer rev'd files.